### PR TITLE
Dev PR 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,23 +5,19 @@ Xplice is my first ever stack-bytecode-based language. The goal of this language
 
 ### Philosophy:
  - Explicit behavior is better for understanding.
- - Concise and clear code helps maintainability.
- - It just works.
+ - Feature creep is bad for traction.
+ - Concise and clear code helps its maintainability.
 
 ### More Docs:
  - [Grammar](./docs/grammar.md)
  - [VM](./docs/vm.md)
 
-### Roadmap:
- - Add native function support!
- - Add while loop support.
- - Add optimization passes for:
-   - Dead branches in control flow.
-   - Peephole optimizing by replacing "useless" instructions.
- - Add support for imports of native functions!
- - Add array and tuple parsing support.
- - Add array and tuple codegen support.
- - Finally add string codegen support!
-
-### Changes:
+### Roadmap of Changes:
+ - **0.1.0** Created the initial bytecode interpreter. Runs Fibonacci.
  - **0.2.0** Added some semantic checking to the bytecode compiler.
+ - **0.3.0** Some support for native functions added.
+ - **0.4.0?** While loops will be added after some IR overhauls.
+ - **0.5.0?** Two basic optimization passes will be added.
+ - **0.6.0?** Sequential types (array, tuple) will be added with a mark-and-sweep GC.
+ - **0.7.0?** Add actual strings.
+ - More versions will be planned...

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -2,34 +2,35 @@
 
 #### Expressions: (add tuples and arrays later!!)
 ```bnf
-<literal> = <boolean> / <integer> / <identifier>
-<access> = <literal> ("::" <literal>)
-<call> = <identifier> "(" (<expr> ",")* ")"
-<unary> = "(" <expr> ")" / "-"? <access> / <call>
-<factor> = <unary> (("*" / "/") <unary>)*
-<term> = <factor> (("+" / "-") <factor>)*
-<equality> = <term> (("==" / "!=") <term>)*
-<compare> = <equality> (("<" / ">") <equality>)*
-<and> = <compare> ("&&" <compare>)*
-<or> = <and> ("||" <and>)*
-<assign> = <access> ("=" <or>)?
-<expr> = <assign>
+<literal> ::= <boolean> / <integer> / <float> / <identifier>
+<access> ::= <literal> ("::" <literal>)
+<call> ::= <identifier> "(" (<expr> ",")* ")"
+<unary> ::= "(" <expr> ")" / "-"? <access> / <call>
+<factor> ::= <unary> (("*" / "/") <unary>)*
+<term> ::= <factor> (("+" / "-") <factor>)*
+<equality> ::= <term> (("==" / "!=") <term>)*
+<compare> ::= <equality> (("<" / ">") <equality>)*
+<and> ::= <compare> ("&&" <compare>)*
+<or> ::= <and> ("||" <and>)*
+<assign> ::= <access> ("=" <or>)?
+<expr> ::= <assign>
 ```
 
 #### Statements:
 ```bnf
-<comment> = "#" ... "#"
-<program> = <top-stmt>*
-<top-stmt> = <import> / <function-decl>
+<comment> ::= "#" ... "#"
+<program> ::= <top-stmt>*
+<top-stmt> ::= <use-native> / <import> / <function-decl>
+<use-native> ::= "use" "func" <identifier> <arg-list> ":" <type-specifier> ";"
 <import> = "import" <identifier> ";"
-<function-decl> = "func" <identifier> <arg-list> ":" <type-specifier> <block>
-<arg-list> = "(" (<arg> ",")* ")"
+<function-decl> ::= "func" <identifier> <arg-list> ":" <type-specifier> <block>
+<arg-list> ::= "(" (<arg> ",")* ")"
 <arg> = <identifier> ":" <type-specifier>
-<type-specifier> = "bool" / "int" / "float" / "string"
-<block> = "{" <nestable-stmt>+ "}"
-<nestable-stmt> = <variable-decl> / <expr-stmt> / <return> / <if>
-<variable-decl> = ("let" / "const") <identifier> ":" <type-specifier> "=" <or> ";"
-<expr-stmt> = <expr> ";"
-<return> = "return" <or> ";"
-<if> = "if" "(" <or> ")" <block> ("else" <block>)?
+<type-specifier> ::= "bool" / "int" / "float" / "string"
+<block> ::= "{" <nestable-stmt>+ "}"
+<nestable-stmt> ::= <variable-decl> / <expr-stmt> / <return> / <if>
+<variable-decl> ::= ("let" / "const") <identifier> ":" <type-specifier> "=" <or> ";"
+<expr-stmt> ::= <expr> ";"
+<return> ::= "return" <or> ";"
+<if> ::= "if" "(" <or> ")" <block> ("else" <block>)?
 ```

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -12,7 +12,7 @@
 <compare> ::= <equality> (("<" / ">") <equality>)*
 <and> ::= <compare> ("&&" <compare>)*
 <or> ::= <and> ("||" <and>)*
-<assign> ::= <access> ("=" <or>)?
+<assign> ::= <unary> ("=" <or>)?
 <expr> ::= <assign>
 ```
 
@@ -30,7 +30,7 @@
 <block> ::= "{" <nestable-stmt>+ "}"
 <nestable-stmt> ::= <variable-decl> / <expr-stmt> / <return> / <if>
 <variable-decl> ::= ("let" / "const") <identifier> ":" <type-specifier> "=" <or> ";"
-<expr-stmt> ::= <expr> ";"
+<expr-stmt> ::= <assign> ";"
 <return> ::= "return" <or> ";"
 <if> ::= "if" "(" <or> ")" <block> ("else" <block>)?
 ```

--- a/includes/codegen/disassembler.hpp
+++ b/includes/codegen/disassembler.hpp
@@ -78,6 +78,7 @@ namespace XLang::Codegen {
             "stack",
             "heap",
             "routines",
+            "natives",
             "frame_slot",
             "none",
         };

--- a/includes/codegen/emit_pass.hpp
+++ b/includes/codegen/emit_pass.hpp
@@ -211,7 +211,7 @@ namespace XLang::Codegen {
 
                 const auto& ir_unit = ir_steps[node_id];
 
-                if (ir_unit.index() == 0) {
+                if (std::holds_alternative<Unit>(ir_unit)) {
                     const auto& [steps, next_id] = std::get<Unit>(ir_unit);
 
                     for (const auto& step : steps) {

--- a/includes/codegen/graph_pass.hpp
+++ b/includes/codegen/graph_pass.hpp
@@ -7,6 +7,7 @@
 #include <variant>
 #include <vector>
 #include "semantics/tags.hpp"
+#include "semantics/analysis.hpp"
 #include "syntax/expr_visitor_base.hpp"
 #include "syntax/stmt_visitor_base.hpp"
 #include "syntax/stmts.hpp"
@@ -109,6 +110,8 @@ namespace XLang::Codegen {
 
         std::string_view m_old_src;
 
+        const Semantics::NativeHints* m_native_hints_p;
+
         /// @note simulates size of a callee's stack values frame
         int m_stack_score;
 
@@ -118,15 +121,12 @@ namespace XLang::Codegen {
         [[nodiscard]] int next_const_id() noexcept;
         [[nodiscard]] int next_func_id() noexcept;
         [[nodiscard]] int next_param_id() noexcept;
-        // [[nodiscard]] int curr_const_id() noexcept;
-        // [[nodiscard]] int curr_local_id() noexcept;
-        // [[nodiscard]] int curr_func_id() noexcept;
-        // [[nodiscard]] int curr_param_id() noexcept;
+
         [[nodiscard]] Locator new_obj_location(Semantics::ArrayType array_tag);
         [[nodiscard]] Locator new_obj_location(Semantics::TupleType tuple_tag);
         [[maybe_unused]] bool delete_location(const Locator& loc);
         const Locator& lookup_named_location(std::string_view name) const;
-        const Locator& lookup_callable_name(std::string_view name) const;
+        [[nodiscard]] Locator lookup_callable_name(std::string_view name) const;
 
         void commit_current_consts();
 
@@ -145,13 +145,14 @@ namespace XLang::Codegen {
         [[nodiscard]] std::any help_gen_assign(const Syntax::Binary& expr);
 
     public:
-        GraphPass(std::string_view old_source);
+        GraphPass(std::string_view old_source, const Semantics::NativeHints* native_hints_p_) noexcept;
 
         [[nodiscard]] std::any visit_literal(const Syntax::Literal& expr) override;
         [[nodiscard]] std::any visit_unary(const Syntax::Unary& expr) override;
         [[nodiscard]] std::any visit_binary(const Syntax::Binary& expr) override;
         [[nodiscard]] std::any visit_call(const Syntax::Call& expr) override;
 
+        [[nodiscard]] std::any visit_native_use(const Syntax::NativeUse& stmt) override;
         [[nodiscard]] std::any visit_import(const Syntax::Import& stmt) override;
         [[nodiscard]] std::any visit_variable_decl(const Syntax::VariableDecl& stmt) override;
         [[maybe_unused]] std::any visit_function_decl(const Syntax::FunctionDecl& stmt) override;

--- a/includes/codegen/graph_pass.hpp
+++ b/includes/codegen/graph_pass.hpp
@@ -125,7 +125,7 @@ namespace XLang::Codegen {
         [[nodiscard]] Locator new_obj_location(Semantics::ArrayType array_tag);
         [[nodiscard]] Locator new_obj_location(Semantics::TupleType tuple_tag);
         [[maybe_unused]] bool delete_location(const Locator& loc);
-        const Locator& lookup_named_location(std::string_view name) const;
+        [[nodiscard]] Locator lookup_named_location(std::string_view name) const;
         [[nodiscard]] Locator lookup_callable_name(std::string_view name) const;
 
         void commit_current_consts();

--- a/includes/codegen/steps.hpp
+++ b/includes/codegen/steps.hpp
@@ -8,6 +8,7 @@ namespace XLang::Codegen {
         temp_stack,
         obj_heap,
         routines,
+        natives,
         frame_slot,
         none,
         last

--- a/includes/frontend/parser.hpp
+++ b/includes/frontend/parser.hpp
@@ -62,6 +62,7 @@ namespace XLang::Frontend {
 
         [[nodiscard]] ParseDump parse_program();
         [[nodiscard]] Syntax::StmtPtr parse_top_stmt();
+        [[nodiscard]] Syntax::StmtPtr parse_native_use();
         [[nodiscard]] Syntax::StmtPtr parse_import();
         [[nodiscard]] Syntax::StmtPtr parse_function_decl();
         [[nodiscard]] std::vector<Syntax::ArgDecl> parse_arg_list();

--- a/includes/syntax/stmt_base.hpp
+++ b/includes/syntax/stmt_base.hpp
@@ -8,6 +8,7 @@ namespace XLang::Syntax {
     struct Stmt {
         virtual ~Stmt() = default;
 
+        virtual bool is_directive() const noexcept = 0;
         virtual bool is_declarative() const noexcept = 0;
         virtual bool is_control_flow() const noexcept = 0;
         virtual bool is_expr_stmt() const noexcept = 0;

--- a/includes/syntax/stmt_visitor_base.hpp
+++ b/includes/syntax/stmt_visitor_base.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 namespace XLang::Syntax {
+    struct NativeUse;
     struct Import;
     struct VariableDecl;
     struct FunctionDecl;
@@ -14,6 +15,7 @@ namespace XLang::Syntax {
     public:
         virtual ~StmtVisitor() = default;
 
+        virtual Result visit_native_use(const NativeUse& stmt) = 0;
         virtual Result visit_import(const Import& stmt) = 0;
         virtual Result visit_variable_decl(const VariableDecl& stmt) = 0;
         virtual Result visit_function_decl(const FunctionDecl& stmt) = 0;

--- a/includes/syntax/stmts.hpp
+++ b/includes/syntax/stmts.hpp
@@ -23,6 +23,7 @@ namespace XLang::Syntax {
 
         NativeUse(Semantics::TypeInfo typing_, std::vector<ArgDecl> args_, Frontend::Token native_name_) noexcept;
 
+        bool is_directive() const noexcept override;
         bool is_declarative() const noexcept override;
         bool is_control_flow() const noexcept override;
         bool is_expr_stmt() const noexcept override;
@@ -36,6 +37,7 @@ namespace XLang::Syntax {
 
         Import(const Frontend::Token& unit_name_) noexcept;
 
+        bool is_directive() const noexcept override;
         bool is_declarative() const noexcept override;
         bool is_control_flow() const noexcept override;
         bool is_expr_stmt() const noexcept override;
@@ -52,6 +54,7 @@ namespace XLang::Syntax {
 
         explicit VariableDecl(Semantics::TypeInfo typing_, const Frontend::Token& var_name_, ExprPtr init_expr_, bool readonly_) noexcept;
 
+        bool is_directive() const noexcept override;
         bool is_declarative() const noexcept override;
         bool is_control_flow() const noexcept override;
         bool is_expr_stmt() const noexcept override;
@@ -68,6 +71,7 @@ namespace XLang::Syntax {
 
         FunctionDecl(Semantics::TypeInfo typing_, const std::vector<ArgDecl>& args_, const Frontend::Token& name_, StmtPtr body_) noexcept;
 
+        bool is_directive() const noexcept override;
         bool is_declarative() const noexcept override;
         bool is_control_flow() const noexcept override;
         bool is_expr_stmt() const noexcept override;
@@ -81,6 +85,7 @@ namespace XLang::Syntax {
 
         ExprStmt(ExprPtr inner_) noexcept;
 
+        bool is_directive() const noexcept override;
         bool is_declarative() const noexcept override;
         bool is_control_flow() const noexcept override;
         bool is_expr_stmt() const noexcept override;
@@ -94,6 +99,7 @@ namespace XLang::Syntax {
 
         Block(std::vector<StmtPtr> stmts_) noexcept;
 
+        bool is_directive() const noexcept override;
         bool is_declarative() const noexcept override;
         bool is_control_flow() const noexcept override;
         bool is_expr_stmt() const noexcept override;
@@ -107,6 +113,7 @@ namespace XLang::Syntax {
 
         Return(ExprPtr result_expr_) noexcept;
 
+        bool is_directive() const noexcept override;
         bool is_declarative() const noexcept override;
         bool is_control_flow() const noexcept override;
         bool is_expr_stmt() const noexcept override;
@@ -122,6 +129,7 @@ namespace XLang::Syntax {
 
         If(ExprPtr test_, StmtPtr truthy_body_, StmtPtr falsy_body_) noexcept;
 
+        bool is_directive() const noexcept override;
         bool is_declarative() const noexcept override;
         bool is_control_flow() const noexcept override;
         bool is_expr_stmt() const noexcept override;

--- a/includes/syntax/stmts.hpp
+++ b/includes/syntax/stmts.hpp
@@ -9,7 +9,28 @@
 
 namespace XLang::Syntax {
     using StmtPtr = std::unique_ptr<Stmt>;
-    
+
+    struct ArgDecl {
+        Semantics::TypeInfo type;
+        Frontend::Token name;
+    };
+
+    /// @brief Represents `<use-native>` statements within Xplice code so that native functions are both forward declared and activated.
+    struct NativeUse : public Stmt {
+        Semantics::TypeInfo typing;
+        std::vector<ArgDecl> args;
+        Frontend::Token native_name;
+
+        NativeUse(Semantics::TypeInfo typing_, std::vector<ArgDecl> args_, Frontend::Token native_name_) noexcept;
+
+        bool is_declarative() const noexcept override;
+        bool is_control_flow() const noexcept override;
+        bool is_expr_stmt() const noexcept override;
+        Semantics::TypeInfo possible_result_type() const noexcept override;
+        void accept_visitor(StmtVisitor<void>& visitor) const override;
+        std::any accept_visitor(StmtVisitor<std::any>& visitor) const override;
+    };
+
     struct Import : public Stmt {
         Frontend::Token unit_name;
 
@@ -37,11 +58,6 @@ namespace XLang::Syntax {
         Semantics::TypeInfo possible_result_type() const noexcept override;
         void accept_visitor(StmtVisitor<void>& visitor) const override;
         std::any accept_visitor(StmtVisitor<std::any>& visitor) const override;
-    };
-
-    struct ArgDecl {
-        Semantics::TypeInfo type;
-        Frontend::Token name;
     };
 
     struct FunctionDecl : public Stmt {

--- a/includes/vm/vm.hpp
+++ b/includes/vm/vm.hpp
@@ -24,6 +24,26 @@ namespace XLang::VM {
 
         void add_native_function(int native_id, const NativeFunction& func) noexcept;
 
+        const Value& peek_stack_top() const noexcept;
+        void push_from_native(Value temp) noexcept;
+
+        void handle_halt();
+        void handle_push(const Codegen::Locator& arg);
+        void handle_pop(const Codegen::Locator& arg);
+        void handle_peek(const Codegen::Locator& arg);
+
+        /* NOTE: implement make_array, make_tuple, access_field... */
+
+        void handle_load_const(const Codegen::Locator& arg);
+        void handle_negate();
+        void handle_arithmetic(Opcode op);
+        void handle_compare(Opcode op);
+        void handle_logical(Opcode op);
+        void handle_jump_not_if(const Codegen::Locator& arg);
+        void handle_return(const Codegen::Locator& arg);
+        void handle_call(const Codegen::Locator& local_func_id, int argc);
+        void handle_native_call(int module_id, int native_id, int argc);
+
     private:
         static constexpr std::array<int, static_cast<std::size_t>(Opcode::last)> opcode_arity = {
             0,
@@ -59,23 +79,6 @@ namespace XLang::VM {
 
         [[nodiscard]] Opcode decode_opcode() const noexcept;
         [[nodiscard]] Codegen::Locator decode_arg(int arg_num) const noexcept;
-        void handle_halt();
-        void handle_push(const Codegen::Locator& arg);
-        void handle_pop(const Codegen::Locator& arg);
-        void handle_peek(const Codegen::Locator& arg);
-
-        /* NOTE: implement make_array, make_tuple, access_field... */
-
-        void handle_load_const(const Codegen::Locator& arg);
-        void handle_negate();
-        void handle_arithmetic(Opcode op);
-        void handle_compare(Opcode op);
-        void handle_logical(Opcode op);
-        void handle_jump_not_if(const Codegen::Locator& arg);
-        void handle_return(const Codegen::Locator& arg);
-        void handle_call(const Codegen::Locator& local_func_id, int argc);
-        void handle_native_call(int module_id, int native_id, int argc);
-
 
         XpliceProgram m_program_funcs;
         std::unordered_map<int, NativeFunction> m_native_funcs;

--- a/src/codegen/disassembler.cpp
+++ b/src/codegen/disassembler.cpp
@@ -60,6 +60,11 @@ namespace XLang::Codegen {
                 print_arg();
                 print_arg();
                 break;
+            case 3:
+                print_arg();
+                print_arg();
+                print_arg();
+                break;
             default:
                 std::print("...");
                 break;

--- a/src/codegen/ir_printer.cpp
+++ b/src/codegen/ir_printer.cpp
@@ -38,6 +38,7 @@ namespace XLang::Codegen {
         "stack",
         "heap",
         "routines",
+        "natives",
         "frame_slot",
         "none"
     };

--- a/src/frontend/lexer.cpp
+++ b/src/frontend/lexer.cpp
@@ -1,11 +1,11 @@
 #include <initializer_list>
-#include <iostream>
 #include "frontend/token.hpp"
 #include "frontend/lexer.hpp"
 
 namespace XLang::Frontend {
     static std::initializer_list<LexicalEntry> entries = {
-        LexicalEntry {"import", LexTag::keyword},
+        LexicalEntry {"use", LexTag::keyword},
+        {"import", LexTag::keyword},
         {"func", LexTag::keyword},
         {"import", LexTag::keyword},
         {"if", LexTag::keyword},

--- a/src/syntax/exprs.cpp
+++ b/src/syntax/exprs.cpp
@@ -1,5 +1,4 @@
 #include <utility>
-#include <typeinfo>
 #include "syntax/exprs.hpp"
 
 namespace XLang::Syntax {

--- a/src/syntax/stmts.cpp
+++ b/src/syntax/stmts.cpp
@@ -5,6 +5,10 @@ namespace XLang::Syntax {
     NativeUse::NativeUse(Semantics::TypeInfo typing_, std::vector<ArgDecl> args_, Frontend::Token native_name_) noexcept
     : typing {std::move(typing_)}, args {std::move(args_)}, native_name {native_name_} {}
 
+    bool NativeUse::is_directive() const noexcept {
+        return true;
+    }
+
     bool NativeUse::is_declarative() const noexcept {
         return true;
     }
@@ -17,7 +21,6 @@ namespace XLang::Syntax {
         return false;
     }
 
-    /// @note This actually gives the full signature of a "used" native function.
     Semantics::TypeInfo NativeUse::possible_result_type() const noexcept {
         return typing;
     }
@@ -33,6 +36,10 @@ namespace XLang::Syntax {
 
     Import::Import(const Frontend::Token& unit_name_) noexcept
     : unit_name {unit_name_} {}
+
+    bool Import::is_directive() const noexcept {
+        return true;
+    }
 
     bool Import::is_declarative() const noexcept {
         return true;
@@ -62,6 +69,10 @@ namespace XLang::Syntax {
     VariableDecl::VariableDecl(Semantics::TypeInfo typing_, const Frontend::Token& name_, ExprPtr init_expr_, bool readonly_) noexcept
     : typing {std::move(typing_)}, name {name_}, init_expr {std::move(init_expr_)}, readonly {readonly_} {}
 
+    bool VariableDecl::is_directive() const noexcept {
+        return false;
+    }
+
     bool VariableDecl::is_declarative() const noexcept {
         return true;
     }
@@ -90,6 +101,10 @@ namespace XLang::Syntax {
     FunctionDecl::FunctionDecl(Semantics::TypeInfo typing_, const std::vector<ArgDecl>& args_, const Frontend::Token& name_, StmtPtr body_) noexcept
     : typing {std::move(typing_)}, args {args_}, name {name_}, body {std::move(body_)} {}
 
+    bool FunctionDecl::is_directive() const noexcept {
+        return false;
+    }
+
     bool FunctionDecl::is_declarative() const noexcept {
         return true;
     }
@@ -117,6 +132,10 @@ namespace XLang::Syntax {
 
     ExprStmt::ExprStmt(ExprPtr inner_) noexcept
     : inner {std::move(inner_)} {}
+
+    bool ExprStmt::is_directive() const noexcept {
+        return false;
+    }
 
     bool ExprStmt::is_declarative() const noexcept {
         return false;
@@ -148,6 +167,10 @@ namespace XLang::Syntax {
     Block::Block(std::vector<StmtPtr> stmts_) noexcept
     : stmts {std::move(stmts_)} {}
 
+    bool Block::is_directive() const noexcept {
+        return false;
+    }
+
     bool Block::is_declarative() const noexcept {
         return false;
     }
@@ -175,6 +198,10 @@ namespace XLang::Syntax {
 
     Return::Return(ExprPtr result_expr_) noexcept
     : result_expr {std::move(result_expr_)} {}
+
+    bool Return::is_directive() const noexcept {
+        return false;
+    }
 
     bool Return::is_declarative() const noexcept {
         return false;
@@ -205,6 +232,10 @@ namespace XLang::Syntax {
 
     If::If(ExprPtr test_, StmtPtr truthy_body_, StmtPtr falsy_body_) noexcept
     : test {std::move(test_)}, truthy_body {std::move(truthy_body_)}, falsy_body {std::move(falsy_body_)} {};
+
+    bool If::is_directive() const noexcept {
+        return false;
+    }
 
     bool If::is_declarative() const noexcept {
         return false;

--- a/src/syntax/stmts.cpp
+++ b/src/syntax/stmts.cpp
@@ -2,6 +2,35 @@
 #include "syntax/stmts.hpp"
 
 namespace XLang::Syntax {
+    NativeUse::NativeUse(Semantics::TypeInfo typing_, std::vector<ArgDecl> args_, Frontend::Token native_name_) noexcept
+    : typing {std::move(typing_)}, args {std::move(args_)}, native_name {native_name_} {}
+
+    bool NativeUse::is_declarative() const noexcept {
+        return true;
+    }
+
+    bool NativeUse::is_control_flow() const noexcept {
+        return false;
+    }
+
+    bool NativeUse::is_expr_stmt() const noexcept {
+        return false;
+    }
+
+    /// @note This actually gives the full signature of a "used" native function.
+    Semantics::TypeInfo NativeUse::possible_result_type() const noexcept {
+        return typing;
+    }
+
+    void NativeUse::accept_visitor(StmtVisitor<void>& visitor) const {
+        visitor.visit_native_use(*this);
+    }
+
+    std::any NativeUse::accept_visitor(StmtVisitor<std::any>& visitor) const {
+        return visitor.visit_native_use(*this);
+    }
+
+
     Import::Import(const Frontend::Token& unit_name_) noexcept
     : unit_name {unit_name_} {}
 

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -168,7 +168,7 @@ namespace XLang::VM {
 
     Opcode VM::decode_opcode() const noexcept {
         // std::cout << "CHUNK: " << current_frame().callee_id <<  ", IPTR: " << m_iptr << '\n';
-        const auto decoded_op = m_program_funcs.func_chunks.at(current_frame().callee_id).view_code().bytecode.at(m_iptr);
+        const auto decoded_op = m_program_funcs.func_chunks.at(current_frame().callee_id).view_code().bytecode[m_iptr];
 
         return static_cast<Opcode>(decoded_op);
     }
@@ -219,7 +219,7 @@ namespace XLang::VM {
             m_values.push_back(Value {arg});
             break;
         case Codegen::Region::frame_slot:
-            m_values.push_back(current_frame().args.at(arg.id));
+            m_values.push_back(current_frame().args[arg.id]);
             break;
         case Codegen::Region::none:
         default:
@@ -337,12 +337,12 @@ namespace XLang::VM {
                     current_frame().callee_id
                 ).view_code().constants.at(num);
             case Codegen::Region::temp_stack:
-                return m_values.at(current_frame().callee_frame_base + num);
+                return m_values[current_frame().callee_frame_base + num];
             case Codegen::Region::obj_heap:
             case Codegen::Region::routines:
                 return Value {arg};
             case Codegen::Region::frame_slot:
-                return current_frame().args.at(num);
+                return current_frame().args[num];
             case Codegen::Region::none:
                 return m_values.back();
             default:

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -9,14 +9,12 @@ namespace XLang::VM {
     static constexpr Codegen::Locator placeholder_arg {Codegen::Region::none, -1}; 
 
     static auto decode_i32 = [] [[nodiscard]] (const std::vector<RuntimeByte>& code_buffer, int position) noexcept {
-        auto result = 0;
+        const auto result_0 = code_buffer[position] & 0x000000ff;
+        const auto result_1 = (code_buffer[position + 1] & 0x0000ff00) >> 8;
+        const auto result_2 = (code_buffer[position + 2] & 0x00ff0000) >> 16;
+        const auto result_3 = (code_buffer[position + 3] & 0xff000000) >> 24;
 
-        result += code_buffer[position] & 0x000000ff;
-        result += (code_buffer[position + 1] & 0x0000ff00) >> 8;
-        result += (code_buffer[position + 2] & 0x00ff0000) >> 16;
-        result += (code_buffer[position + 3] & 0xff000000) >> 24;
-
-        return result;
+        return result_0 + result_1 + result_2 + result_3;
     };
 
     VM::VM(XpliceProgram prgm) noexcept
@@ -132,7 +130,6 @@ namespace XLang::VM {
                 handle_call(op_args[0], op_args[1].id);
                 break;
             case Opcode::xop_call_native:
-                /// TODO: implement codegen for this within the graph_pass!!
                 handle_native_call(op_args[0].id, op_args[1].id, op_args[2].id);
                 break;
             default:
@@ -155,6 +152,7 @@ namespace XLang::VM {
         return func.ptr()(this, args);
     }
 
+    /// @note Registers a native function wrapper to the runtime. The `id` must ascend from 0 to N corresponding to the order of use-native statements!
     void VM::add_native_function(int native_id, const NativeFunction& func) noexcept {
         m_native_funcs[native_id] = func;
     }
@@ -180,9 +178,21 @@ namespace XLang::VM {
         const auto arg_byte_pos = opcode_stride + (arg_num * opcode_arg_stride);
 
         return {
-            .region = static_cast<Codegen::Region>(chunk_view[m_iptr + arg_byte_pos]),
-            .id = decode_i32(chunk_view, m_iptr + arg_byte_pos + 1)
+            .region = static_cast<Codegen::Region>(
+                chunk_view[m_iptr + arg_byte_pos]
+            ),
+            .id = static_cast<int>(
+                decode_i32(chunk_view, m_iptr + arg_byte_pos + 1)
+            )
         };
+    }
+
+    const Value& VM::peek_stack_top() const noexcept {
+        return m_values.back();
+    }
+
+    void VM::push_from_native(Value temp) noexcept {
+        m_values.emplace_back(std::move(temp));
     }
 
     void VM::handle_halt() {
@@ -388,7 +398,7 @@ namespace XLang::VM {
         m_iptr = 0;
     }
 
-    void VM::handle_native_call([[maybe_unused]] int module_id, [[maybe_unused]] int native_id, [[maybe_unused]] int argc) {
+    void VM::handle_native_call([[maybe_unused]] int module_id, int native_id, int argc) {
         ArgStore args;
 
         for (auto arg_count = 0; arg_count < argc; ++arg_count) {

--- a/test_sources/test_4.xplice
+++ b/test_sources/test_4.xplice
@@ -1,21 +1,7 @@
-func sum_n(n: int,): int {
-    let temp: int = n;
-    let ans = 0;
-
-    while (temp > 0) {
-        ans = ans + temp;
-        temp = temp - 1;
-    }
-
-    return ans;
-}
+use func printInt(n: int,): int;
 
 func main(): int {
-    const test = sum_n(10,);
-
-    if (test != 55) {
-        return 1;
-    }
+    printInt(42,);
 
     return 0;
 }

--- a/test_sources/test_5.xplice
+++ b/test_sources/test_5.xplice
@@ -1,13 +1,21 @@
-func main(): int {
-    const original: tuple[int, int] = (42, 24);
-    const x, y = original;
+func sum_n(n: int,): int {
+    let temp: int = n;
+    let ans = 0;
 
-    const reversed: tuple[int, int] = (y, x);
-    const x2, y2 = reversed;
-
-    if (x2 == y && y2 == x) {
-        return 0;
+    while (temp > 0) {
+        ans = ans + temp;
+        temp = temp - 1;
     }
 
-    return 1;
+    return ans;
+}
+
+func main(): int {
+    const test = sum_n(10,);
+
+    if (test != 55) {
+        return 1;
+    }
+
+    return 0;
 }

--- a/test_sources/test_6.xplice
+++ b/test_sources/test_6.xplice
@@ -1,0 +1,13 @@
+func main(): int {
+    const original: tuple[int, int] = (42, 24);
+    const x, y = original;
+
+    const reversed: tuple[int, int] = (y, x);
+    const x2, y2 = reversed;
+
+    if (x2 == y && y2 == x) {
+        return 0;
+    }
+
+    return 1;
+}

--- a/tests/xlang_test_sema.cpp
+++ b/tests/xlang_test_sema.cpp
@@ -24,7 +24,7 @@ using namespace XLang;
     }
 
     Semantics::SemanticsPass sema {source_view};
-    auto sema_errors = sema(parse_result.decls);
+    auto [sema_native_hints, sema_errors] = sema(parse_result.decls);
 
     if (!sema_errors.empty()) {
         std::print(std::cerr, "Semantic errors in file '{}':\n", file_name);


### PR DESCRIPTION
This PR adds working support for native procedures. Note that native procedures must return a status code to the runtime _and_ consume arguments correctly from the stack by arity. Also, it is recommended for such routines to check types of boxed `Value` objects.